### PR TITLE
Encode XML Content

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -29,7 +29,7 @@ function dgs_to_xml( $array, $xml ) {
 
 				//simple key/value child pair
 			} else {
-			$xml->addChild( $key, $value );
+			$xml->addChild( $key, htmlspecialchars($value) );
 		}
 
 	}


### PR DESCRIPTION
Hopefully this approach isn't too overzealous -- it is turning ":" and other allowable characters into htmlentities, but having an "&" in the data was causing the code to break.
